### PR TITLE
fixed 'QueueItem' not defined in example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -86,6 +86,7 @@ You can also use the `kitchen sink <https://tijme.github.io/not-your-average-web
     # example_minimal.py
 
     from nyawc.Options import Options
+    from nyawc.QueueItem import QueueItem
     from nyawc.Crawler import Crawler
     from nyawc.CrawlerActions import CrawlerActions
     from nyawc.http.Request import Request


### PR DESCRIPTION
fixed 'QueueItem' not defined in example

Problem
=================

**QueueItem** is not imported at the top, but called by `cb_crawler_after_finish()` function. Therefore it raised an error that **QueueItem** not defined.

Solution
=================

imported `QueueItem` on top of the example code

``
from nyawc.QueueItem import QueueItem
``
